### PR TITLE
chore: upgrade mr2s-module 0.0.6 to 0.1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.133.0
-mr2s-module==0.0.6
+mr2s-module==0.1.7
 networkx
 numpy
 pydantic==2.12.5

--- a/service/module_optimization_service.py
+++ b/service/module_optimization_service.py
@@ -1,14 +1,14 @@
 from mr2s_module import (
-  QuboMR2SSolver,
-  SAMR2SSolver
+  create_qubo_solver,
+  create_sa_solver
 )
 
 from service.optimization_service import ProxyModuleOptimizationService
 
 NONE_FACE_CYCLE_OPTIMIZATION_SERVICE = ProxyModuleOptimizationService(
-  QuboMR2SSolver()
+  create_qubo_solver()
 )
 
 RAW_SA_OPTIMIZATION_SERVICE = ProxyModuleOptimizationService(
-  SAMR2SSolver()
+  create_sa_solver()
 )

--- a/service/module_solver_protocol.py
+++ b/service/module_solver_protocol.py
@@ -1,6 +1,6 @@
 from typing import Protocol
 
-from mr2s_module import Graph, Solution
+from mr2s_module.domain import Graph, Solution
 
 
 class ModuleSolverProtocol(Protocol):


### PR DESCRIPTION
## Summary
- Bump `mr2s-module` 0.0.6 → 0.1.7
- Switch solver construction to new `create_qubo_solver()` / `create_sa_solver()` factory functions (recommended entry points; QUBO factory wires SA-backed `QuboSolver` with `ApspSumRanker`)
- Import `Graph`/`Solution` from `mr2s_module.domain` — top-level `Solution` export in 0.1.7 is broken upstream (aliased to `typing.Any`)

## Notes
- `Graph(list[Edge])` construction still works in 0.1.7 (`__post_init__` accepts iterables), so `to_mr2s_graph()` needed no change
- No test suite in repo; verified by smoke test — both QUBO and SA solvers return valid orientations on a triangle graph, app imports cleanly