### PR TITLE
fix: qubo 파티션 실패를 500 대신 422로 응답

### DIFF
--- a/docs/api_spec.md
+++ b/docs/api_spec.md
@@ -180,6 +180,7 @@ curl -X POST http://localhost:8000/api/v2/solvers/qubo -H 'Content-Type: applica
 | `400 Bad Request` | Invalid input (malformed edges, missing fields), an option the solver does not accept, or `robin` on a graph with a bridge |
 | `404 Not Found` | Unknown `solver_name`; the message lists valid names |
 | `408 Request Timeout` | Optimization exceeded the 10-second time limit |
+| `422 Unprocessable Entity` | The solver cannot handle this graph — `qubo` on a graph too dense to split into QUBO-embeddable subgraphs. The message names the other solvers; `raw-sa` orients these |
 | `500 Internal Server Error` | Solver ran but failed |
 | `503 Service Unavailable` | Solver could not be constructed — e.g. missing D-Wave credentials |
 
@@ -190,7 +191,7 @@ curl -X POST http://localhost:8000/api/v2/solvers/qubo -H 'Content-Type: applica
 | Name | Aliases | Method | Options | Needs D-Wave |
 |------|---------|--------|---------|--------------|
 | `raw-sa` | `sa` | Simulated annealing directly on graph metrics (APSP + flow), no QUBO | SA options | No |
-| `qubo` | `dnc-qubo`, `dnc-qubo-sa` | Divide-and-conquer partitioning, subgraphs solved as QUBO with a local SA sampler | — | No |
+| `qubo` | `dnc-qubo`, `dnc-qubo-sa` | Divide-and-conquer partitioning, subgraphs solved as QUBO with a local SA sampler. Dense graphs can fail to partition and return `422` | — | No |
 | `robin` | `robbin` | Robbins orientation — single DFS pass that orients every edge | — | No |
 
 ### Options

--- a/router/solver_v2_router.py
+++ b/router/solver_v2_router.py
@@ -8,6 +8,7 @@ from service.solver_catalog import (
   SolverUnavailableError,
   UnknownSolverError,
   create_optimization_service,
+  unsolvable_graph_detail,
 )
 from utils import run_with_timeout
 
@@ -58,4 +59,9 @@ async def optimize_by_solver(solver_name: str, request: SolverRequestDto):
   except ValueError as e:
     raise HTTPException(status_code=400, detail=f"Invalid input: {e}")
   except Exception as e:
+    # A solver that cannot handle this particular graph is a property of the
+    # request, not a server fault, so it must not read as 5xx to the client.
+    detail = unsolvable_graph_detail(solver_name, e)
+    if detail is not None:
+      raise HTTPException(status_code=422, detail=detail)
     raise HTTPException(status_code=500, detail=f"Optimization failed: {e}")

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -15,6 +15,7 @@ _MODULE_ATTRS = {
     "SolverSpec": (".solver_catalog", "SolverSpec"),
     "create_optimization_service": (".solver_catalog", "create_optimization_service"),
     "resolve_solver_spec": (".solver_catalog", "resolve_solver_spec"),
+    "unsolvable_graph_detail": (".solver_catalog", "unsolvable_graph_detail"),
     "UnknownSolverError": (".solver_catalog", "UnknownSolverError"),
     "InvalidSolverOptionError": (".solver_catalog", "InvalidSolverOptionError"),
     "SolverUnavailableError": (".solver_catalog", "SolverUnavailableError"),

--- a/service/solver_catalog.py
+++ b/service/solver_catalog.py
@@ -100,6 +100,33 @@ SOLVER_ALIASES: dict[str, str] = {
 }
 
 
+# The divide-and-conquer QUBO solver raises a plain RuntimeError when it cannot
+# cut a graph into embeddable subgraphs, so the message prefix is the only
+# marker available. A typed exception is tracked upstream in
+# quantum-guardians/mr2s-module#78; switch to it once released.
+PARTITION_FAILURE_PREFIX = "DnC partition failed"
+
+
+def unsolvable_graph_detail(solver_name: str, error: Exception) -> str | None:
+  """Describes `error` as a graph the solver cannot handle.
+
+  Returns None when the error is a genuine server failure (the caller should
+  keep reporting those as 5xx).
+  """
+  if not str(error).startswith(PARTITION_FAILURE_PREFIX):
+    return None
+
+  canonical_name = SOLVER_ALIASES.get(solver_name, solver_name)
+  alternatives = ", ".join(
+    f"'{name}'" for name in sorted(SOLVER_SPECS) if name != canonical_name
+  )
+  return (
+    f"Solver '{canonical_name}' cannot orient this graph: it is too dense to "
+    f"split into QUBO-embeddable subgraphs. Try another solver ({alternatives}) "
+    f"or send a sparser graph. Underlying error: {error}"
+  )
+
+
 def resolve_solver_spec(name: str) -> SolverSpec:
   canonical_name = SOLVER_ALIASES.get(name, name)
   spec = SOLVER_SPECS.get(canonical_name)

--- a/tests/test_solver_v2_errors.py
+++ b/tests/test_solver_v2_errors.py
@@ -1,0 +1,75 @@
+import asyncio
+import importlib
+
+import pytest
+from fastapi import HTTPException
+
+from dto import SolverRequestDto
+from dto.request_v1_dto import WeightedEdgeDto
+# The router package rebinds the name `solver_v2_router` to the APIRouter
+# instance, so the module itself has to come from importlib.
+solver_v2_module = importlib.import_module("router.solver_v2_router")
+from service.solver_catalog import unsolvable_graph_detail
+
+PARTITION_ERROR = RuntimeError(
+  "DnC partition failed: input graph is not embeddable and no embeddable "
+  "subgraph partition was found (vertices=12, edges=17)"
+)
+
+
+class FailingService:
+  """Module-level so the 'spawn' start method can pickle it."""
+
+  def __init__(self, error):
+    self.error = error
+
+  def optimize(self, graph):
+    raise self.error
+
+
+def triangle_request():
+  return SolverRequestDto(
+    edges=[
+      WeightedEdgeDto(vertices=[1, 2], weight=1),
+      WeightedEdgeDto(vertices=[2, 3], weight=1),
+      WeightedEdgeDto(vertices=[1, 3], weight=1),
+    ]
+  )
+
+
+def run_solver(monkeypatch, solver_name, error):
+  monkeypatch.setattr(
+    solver_v2_module,
+    "create_optimization_service",
+    lambda name, options: FailingService(error),
+  )
+  return asyncio.run(
+    solver_v2_module.optimize_by_solver(solver_name, triangle_request())
+  )
+
+
+def test_partition_failure_is_reported_as_unprocessable(monkeypatch):
+  with pytest.raises(HTTPException) as excinfo:
+    run_solver(monkeypatch, "qubo", PARTITION_ERROR)
+
+  assert excinfo.value.status_code == 422
+  assert "raw-sa" in excinfo.value.detail
+
+
+def test_other_runtime_errors_stay_server_errors(monkeypatch):
+  with pytest.raises(HTTPException) as excinfo:
+    run_solver(monkeypatch, "qubo", RuntimeError("Worker process exited unexpectedly"))
+
+  assert excinfo.value.status_code == 500
+
+
+def test_detail_resolves_aliases_and_excludes_the_failing_solver():
+  detail = unsolvable_graph_detail("dnc-qubo", PARTITION_ERROR)
+
+  assert detail is not None
+  assert "'qubo' cannot orient this graph" in detail
+  assert "'raw-sa'" in detail and "'robin'" in detail
+
+
+def test_detail_is_none_for_unrelated_errors():
+  assert unsolvable_graph_detail("qubo", ValueError("Invalid input: no edges")) is None


### PR DESCRIPTION
Closes #37

## 문제

`POST /api/v2/solvers/qubo`가 조밀한 그래프에서 500을 뱉었다.

```
500 {"detail": "Optimization failed: DnC partition failed: input graph is not embeddable and no embeddable subgraph partition was found (vertices=12, edges=17)"}
```

`DnCMr2sSolver`가 그래프를 QUBO로 임베딩 가능한 부분그래프로 못 쪼개면 평문 `RuntimeError`를 던지고, `solver_v2_router`의 마지막 `except Exception`이 그걸 그대로 500으로 감쌌다. 정상적인 요청인데 서버 장애처럼 보이고, 클라이언트는 solver를 바꾸면 된다는 걸 알 방법이 없었다.

트리거는 크기가 아니라 **밀도**다. spanning path + 랜덤 코드 그래프로 5회씩 돌린 결과, 코드 +1·+3(희소)은 n=4~13 전부 성공했지만 코드 +6(조밀)은 n=5·7·10에서 5회 중 2~3회 실패했다. 같은 그래프를 `raw-sa`는 정상 처리한다.

## 변경

- `service/solver_catalog.py`에 `unsolvable_graph_detail()` 추가. 파티션 실패면 사용 가능한 다른 solver 이름을 담은 메시지를, 아니면 `None`을 돌려준다. 별칭(`dnc-qubo`)은 정식 이름으로 정규화한다.
- `router/solver_v2_router.py`는 그 결과가 있을 때만 422로 응답한다. `utils/timeout.py`의 `Worker process exited unexpectedly` 같은 진짜 서버 오류는 500 유지.
- `docs/api_spec.md` v2 오류 표에 422 추가, solver 표의 `qubo` 항목에 밀도 제약 명시.
- `tests/test_solver_v2_errors.py` 추가 (이 저장소 첫 테스트, 새 의존성 없음).

## 검증

```
$ .venv/bin/python -m pytest tests -q
4 passed
```

실제 그래프로도 확인 (mock 아님, n=10 조밀 그래프):

```
seed 3 -> 422 Solver 'qubo' cannot orient this graph: it is too dense to split into
QUBO-embeddable subgraphs. Try another solver ('raw-sa', 'robin') or send a sparser graph.
Underlying error: DnC partition failed: ...
```

## 남은 것

이 PR은 증상을 정직하게 보고할 뿐, 조밀 그래프를 실제로 푸는 건 아니다. 근본 수정은 mr2s-module 쪽 이슈로 등록했다: quantum-guardians/mr2s-module#78 (타입 있는 예외 + 파티션 fallback). 타입 있는 예외가 릴리스되면 여기 문자열 접두사 매칭을 예외 타입 기반으로 바꿔야 한다.